### PR TITLE
Fix invalid random ExpiredToken error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,11 +420,11 @@ pub fn decode(data: &str, key: &[u8], ttl: u32) -> Result<String, BrancaError> {
 
     // TTL check to determine if the token has expired.
     if ttl != 0 {
-        let future = timestamp.checked_add(ttl).expect("TTL too high.");
+        let future = timestamp.checked_add(ttl).expect("TTL too high.") as u64;
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("Failed to obtain timestamp from system clock.")
-            .as_nanos() as u32;
+            .as_secs();
         if future < now {
             return Err(BrancaError::ExpiredToken);
         }
@@ -486,7 +486,7 @@ mod unit_tests {
             &b"supersecretkeyyoushouldnotcommit".to_vec(),
             timestamp,
         )
-            .unwrap();
+        .unwrap();
 
         assert_eq!(
             decode(
@@ -494,7 +494,7 @@ mod unit_tests {
                 &b"supersecretkeyyoushouldnotcommit".to_vec(),
                 0
             )
-                .unwrap(),
+            .unwrap(),
             "Hello world!"
         );
     }
@@ -508,7 +508,7 @@ mod unit_tests {
             &b"supersecretkeyyoushouldnotcommit".to_vec(),
             timestamp,
         )
-            .unwrap();
+        .unwrap();
 
         assert_eq!(
             decode(
@@ -516,7 +516,7 @@ mod unit_tests {
                 &b"supersecretkeyyoushouldnotcommit".to_vec(),
                 0
             )
-                .unwrap(),
+            .unwrap(),
             "Hello world!"
         );
     }
@@ -531,13 +531,13 @@ mod unit_tests {
             &b"supersecretkeyyoushouldnotcommit".to_vec(),
             timestamp,
         )
-            .unwrap();
+        .unwrap();
         let json = decode(
             branca_token.as_str(),
             &b"supersecretkeyyoushouldnotcommit".to_vec(),
             0,
         )
-            .unwrap();
+        .unwrap();
         let serialized_json: JSONTest = serde_json::from_str(json.as_str()).unwrap();
 
         assert_eq!(serialized_json.a, "some string");
@@ -556,13 +556,13 @@ mod unit_tests {
             &b"supersecretkeyyoushouldnotcommit".to_vec(),
             timestamp,
         )
-            .unwrap();
+        .unwrap();
         let json = decode(
             branca_token.as_str(),
             &b"supersecretkeyyoushouldnotcommit".to_vec(),
             0,
         )
-            .unwrap();
+        .unwrap();
         let serialized_json: JSONTest = serde_json::from_str(json.as_str()).unwrap();
 
         assert_eq!(serialized_json.a, "some string");


### PR DESCRIPTION
The logical error is produced when trying to convert from u128 (nano
secs) to u32 (secs) in the check of TTL

Example test code:

__Rust Version: rustc 1.41.0 (5e1a79984 2020-01-27)__

```
use branca::{decode, Branca};
use std::{thread, time};

fn main() {
    let key = b"supersecretkeyyoushouldnotcommit".to_vec();
    let branca = Branca::new(&key).unwrap();
    let token = branca.encode("Mensaje, Hola").unwrap();

    let d_secs = time::Duration::from_secs(5);

    loop {
        let b = decode(&token, &key, 3600_000);
        println!("Branca Result {:?} => Token {}", b, token);

        thread::sleep(d_secs);
    }
}

```

branca = "0.9"

Output: 

```

Output Error:

Branca Result Ok("Mensaje, Hola") => Token XbhP8jilrQlHwIBxFMFUytF8sBpllvilipCHG8xkk5ZksdtaPEcLeb6bTZ30ok4v5zL5oHEbHPzG7Q
Branca Result Err(ExpiredToken) => Token XbhP8jilrQlHwIBxFMFUytF8sBpllvilipCHG8xkk5ZksdtaPEcLeb6bTZ30ok4v5zL5oHEbHPzG7Q
Branca Result Err(ExpiredToken) => Token XbhP8jilrQlHwIBxFMFUytF8sBpllvilipCHG8xkk5ZksdtaPEcLeb6bTZ30ok4v5zL5oHEbHPzG7Q
Branca Result Ok("Mensaje, Hola") => Token XbhP8jilrQlHwIBxFMFUytF8sBpllvilipCHG8xkk5ZksdtaPEcLeb6bTZ30ok4v5zL5oHEbHPzG7Q
Branca Result Ok("Mensaje, Hola") => Token XbhP8jilrQlHwIBxFMFUytF8sBpllvilipCHG8xkk5ZksdtaPEcLeb6bTZ30ok4v5zL5oHEbHPzG7Q
Branca Result Ok("Mensaje, Hola") => Token XbhP8jilrQlHwIBxFMFUytF8sBpllvilipCHG8xkk5ZksdtaPEcLeb6bTZ30ok4v5zL5oHEbHPzG7Q
Branca Result Ok("Mensaje, Hola") => Token XbhP8jilrQlHwIBxFMFUytF8sBpllvilipCHG8xkk5ZksdtaPEcLeb6bTZ30ok4v5zL5oHEbHPzG7Q
Branca Result Err(ExpiredToken) => Token XbhP8jilrQlHwIBxFMFUytF8sBpllvilipCHG8xkk5ZksdtaPEcLeb6bTZ30ok4v5zL5oHEbHPzG7Q
Branca Result Err(ExpiredToken) => Token XbhP8jilrQlHwIBxFMFUytF8sBpllvilipCHG8xkk5ZksdtaPEcLeb6bTZ30ok4v5zL5oHEbHPzG7Q
Branca Result Ok("Mensaje, Hola") => Token XbhP8jilrQlHwIBxFMFUytF8sBpllvilipCHG8xkk5ZksdtaPEcLeb6bTZ30ok4v5zL5oHEbHPzG7Q
Branca Result Ok("Mensaje, Hola") => Token XbhP8jilrQlHwIBxFMFUytF8sBpllvilipCHG8xkk5ZksdtaPEcLeb6bTZ30ok4v5zL5oHEbHPzG7Q
Branca Result Ok("Mensaje, Hola") => Token XbhP8jilrQlHwIBxFMFUytF8sBpllvilipCHG8xkk5ZksdtaPEcLeb6bTZ30ok4v5zL5oHEbHPzG7Q

```

After change:

```
Branca Result Ok("Mensaje, Hola") => Token Xb45cIEGQjlXM3BHhVmhhVXXSnUbTae5ZzpC1udOpWUxwiothbo7UZvnCZEil1oGYrld1ovjguiL0h
Branca Result Ok("Mensaje, Hola") => Token Xb45cIEGQjlXM3BHhVmhhVXXSnUbTae5ZzpC1udOpWUxwiothbo7UZvnCZEil1oGYrld1ovjguiL0h
Branca Result Ok("Mensaje, Hola") => Token Xb45cIEGQjlXM3BHhVmhhVXXSnUbTae5ZzpC1udOpWUxwiothbo7UZvnCZEil1oGYrld1ovjguiL0h
Branca Result Ok("Mensaje, Hola") => Token Xb45cIEGQjlXM3BHhVmhhVXXSnUbTae5ZzpC1udOpWUxwiothbo7UZvnCZEil1oGYrld1ovjguiL0h
Branca Result Ok("Mensaje, Hola") => Token Xb45cIEGQjlXM3BHhVmhhVXXSnUbTae5ZzpC1udOpWUxwiothbo7UZvnCZEil1oGYrld1ovjguiL0h
Branca Result Ok("Mensaje, Hola") => Token Xb45cIEGQjlXM3BHhVmhhVXXSnUbTae5ZzpC1udOpWUxwiothbo7UZvnCZEil1oGYrld1ovjguiL0h
Branca Result Ok("Mensaje, Hola") => Token Xb45cIEGQjlXM3BHhVmhhVXXSnUbTae5ZzpC1udOpWUxwiothbo7UZvnCZEil1oGYrld1ovjguiL0h
Branca Result Ok("Mensaje, Hola") => Token Xb45cIEGQjlXM3BHhVmhhVXXSnUbTae5ZzpC1udOpWUxwiothbo7UZvnCZEil1oGYrld1ovjguiL0h
```