### PR TITLE
Update orion to v0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 base-x = "0.2.3"
 byteorder = "1.3.2"
-orion = "0.14.2"
+orion = "0.15.0"
 
 [dev-dependencies]
 serde = "^1.0"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _NOTE: Branca uses orion for its cryptographic primitives and due to orion not r
 
 # Requirements
 
-* Rust 1.33
+* Rust 1.37
 * Cargo
 
 # Installation


### PR DESCRIPTION
`v0.15` brings, among other things, performance improvements to XChaCha20Poly1305, but also bumps MSRV. I didn't see any tests in CI that tested MSRV for `branca` with `1.33`, but `1.37` is tested for orion in CI.