### PR TITLE
Test for empty input compliance and MSRV bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 base-x = "0.2.6"
 byteorder = "1.3.4"
-orion = "0.15.3"
+orion = "~0.15.4"
 
 [dev-dependencies]
 serde = "^1.0"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _NOTE: Branca uses orion for its cryptographic primitives and due to orion not r
 
 # Requirements
 
-* Rust 1.37
+* Rust 1.41
 * Cargo
 
 # Installation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -734,11 +734,12 @@ mod unit_tests {
 
     #[test]
     pub fn test_empty_payload_encode_decode() {
-        let key = b"supersecretkeyyoushouldnotcommit".to_vec();
-        let ctx = Branca::new(&key).unwrap();
+        let key = b"supersecretkeyyoushouldnotcommit";
+        let ctx = Branca::new(key).unwrap();
+        assert!(ctx.encode("").is_ok());
+
         // Empty token cross-checked with pybranca
-        let decoded = ctx.decode("4tGtt5wP5DCXzPhNbovMwEg9saksXSdmhvFbdrZrQjXEWf09BtuAK1wG5lpG0", 1000).unwrap();
-        
+        let decoded = ctx.decode("4tGtt5wP5DCXzPhNbovMwEg9saksXSdmhvFbdrZrQjXEWf09BtuAK1wG5lpG0", 0).unwrap();
         assert_eq!("", decoded);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,7 +392,7 @@ pub fn decode(data: &str, key: &[u8], ttl: u32) -> Result<String, BrancaError> {
         Err(UnknownCryptoError) => return Err(BrancaError::BadKeyLength),
     };
 
-    if data.len() < 62 {
+    if data.len() < 61 {
         return Err(BrancaError::InvalidBase62Token);
     }
 
@@ -730,5 +730,16 @@ mod unit_tests {
         // to_string() should not panic.
         // See: https://github.com/return/branca/issues/14
         let _tostr = BrancaError::InvalidTokenVersion.to_string();
+    }
+
+    #[test]
+    pub fn test_empty_payload_encode_decode() {
+        let key = b"supersecretkeyyoushouldnotcommit".to_vec();
+        let mut ctx = Branca::new(&key).unwrap();
+        ctx.timestamp = 0; // Make sure current gets used.
+
+        let token = ctx.encode("").unwrap();
+        let decoded = ctx.decode(&token, 1000).unwrap();
+        assert_eq!("", decoded);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -735,11 +735,10 @@ mod unit_tests {
     #[test]
     pub fn test_empty_payload_encode_decode() {
         let key = b"supersecretkeyyoushouldnotcommit".to_vec();
-        let mut ctx = Branca::new(&key).unwrap();
-        ctx.timestamp = 0; // Make sure current gets used.
-
-        let token = ctx.encode("").unwrap();
-        let decoded = ctx.decode(&token, 1000).unwrap();
+        let ctx = Branca::new(&key).unwrap();
+        // Empty token cross-checked with pybranca
+        let decoded = ctx.decode("4tGtt5wP5DCXzPhNbovMwEg9saksXSdmhvFbdrZrQjXEWf09BtuAK1wG5lpG0", 1000).unwrap();
+        
         assert_eq!("", decoded);
     }
 }


### PR DESCRIPTION
As a continuation of https://github.com/return/branca/issues/10 and the specification of payload

> Payload itself is an arbitrary sequence of bytes.

this PR pins the Orion version, to the one where support for empty input was added ([version pin doc](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#tilde-requirements)). This was not allowed in Orion before `0.15.4`. This implementation would simply error if the input was empty, where pybranca could return `4tGtt5wP5DCXzPhNbovMwEg9saksXSdmhvFbdrZrQjXEWf09BtuAK1wG5lpG0` with

```python
from branca import Branca

f = Branca(key="supersecretkeyyoushouldnotcommit")
ct = f.encode(b"")
```

`0.15.4` of Orion also bumps the MSRV to `1.41` to due a bump in the `subtle` dependency.