### PR TITLE
Fix not using builder nonce in token encoding

### DIFF
--- a/fuzz/fuzz_targets/fuzz_branca.rs
+++ b/fuzz/fuzz_targets/fuzz_branca.rs
@@ -18,7 +18,7 @@ fuzz_target!(|data: &[u8]| {
     csprng.try_fill_bytes(&mut key).unwrap();
 
 
-    let ctx = Branca::new(&key).unwrap();
+    let mut ctx = Branca::new(&key).unwrap();
 
     if !ctx.decode(&String::from_utf8_lossy(data).to_string(), 0).is_err() {
         panic!("Decoded random string successfully");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -772,4 +772,16 @@ mod unit_tests {
                 == BrancaError::InvalidBase62Token
         );
     }
+
+    #[test]
+    pub fn test_builder_nonce_is_correctly_used() {
+        let key = b"supersecretkeyyoushouldnotcommit";
+        let ctx = Branca::new(key).unwrap();
+        let token = ctx.encode(b"").unwrap();
+        
+        let raw_token = b62_decode(BASE62, &token).unwrap();
+        let nonce = &raw_token[5..29];
+
+        assert_eq!(&ctx.nonce()[..], nonce);
+    }
 }


### PR DESCRIPTION
Previously, the nonce that the builder generated in `new()` was never being used, because a new nonce was generated in `encode()`. Thus, calling the nonce getter on the struct would never return the nonce _**actually used**_.

This PR changes the builder to generate a new nonce on each `encode()` call, such that retrieving the `nonce` via the struct, actually returns the nonce used to encrypt the most recent token.